### PR TITLE
Add structural type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,5 @@
 import { DocumentNode } from 'graphql';
 
-export interface TypedDocumentNode<Result = { [key: string]: any }, Variables = { [key: string]: any }> extends DocumentNode { }
+export interface TypedDocumentNode<Result = { [key: string]: any }, Variables = { [key: string]: any }> extends DocumentNode {
+  apiType?: (variables: Variables) => Result;
+}


### PR DESCRIPTION
TypeScript is structurally typed, so the current implementation is pretty limited in what it will enforce. e.g. https://github.com/dotansimha/graphql-typed-document-node/blob/master/examples/apollo-client-3/index.ts does not currently enforce the type of the variables.

By adding this optional property, even though no code will ever implement this method, it forces TypeScript to actually verify the types.