### PR TITLE
Update shopify graphql-typed link

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ If you think your patch can be helpful for other developers as well, feel free t
 # Thanks & Inspiration
 
 - https://github.com/dotansimha/graphql-code-generator/issues/1777#issue-437813742 for the concept of generating unified clients support
-- https://github.com/Shopify/graphql-tools-web/blob/main/packages/graphql-typed/index.ts for similar idea
+- https://github.com/Shopify/quilt/blob/main/packages/graphql-typed/src/index.ts for similar idea


### PR DESCRIPTION
We moved some stuff around, here's where the graphql-typed package lives now