### PR TITLE
Upgrade GraphQL version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@changesets/changelog-github": "0.4.8",
     "@types/node": "14.17.33",
     "bob-the-bundler": "5.0.1",
-    "graphql": "16.6.0",
+    "graphql": "16.8.1",
     "typescript": "4.9.5"
   }
 }


### PR DESCRIPTION
Graphql 16.6.0 has a vulnerability: CVE-2023-26144. More info: https://avd.aquasec.com/nvd/2023/cve-2023-26144/