### PR TITLE
fix: update variable type variance to bivariant

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@ export interface DocumentTypeDecoration<TResult, TVariables> {
    * and that the Result is assignable to whatever you pass your result to. The method is never actually
    * implemented, but the type is valid because we list it as optional
    */
-  __apiType?: (variables: TVariables) => TResult;
+  __apiType?(variables: TVariables): TResult;
 }
 
 export interface TypedDocumentNode<


### PR DESCRIPTION
# Summary
I've updated the implementation of the `__apiType` method to shorthand method definition. This modification enables bivariance in the variable type.

# Details
Let's consider a function that takes a specific `TypedDocumentNode` with certain requirements. Assume this function, `queryAnimal`, receives a Graphql query with `AnimalQueryResult` as the return type and `AnimalQueryVariable` as the argument type.

Suppose `dogDocumentNode` has a narrower scope than `AnimalQueryResult` for the Return Type (`{ name: string; id: string; age: number }`) and a narrower scope than `AnimalQueryVariable` for the Variable Type (`{ id: string }`). As a result, it should be usable as an argument for `queryAnimal`. However, due to the Variable Type of `TypedDocumentNode` being a function argument, TypeScript conducts type checking contravariantly for the VariableType, making it ineligible as an argument.

To create a bivariant function argument in TypeScript, the method needs to be defined as a Shorthand Definition.
```typescript

type ResultOf<T> = T extends TypedDocumentNode<infer R, any> ? R : never;
type VariablesOf<T> = T extends TypedDocumentNode<any, infer V> ? V : never;

// type TypedDocumentNode<R, V> = { __apiType?: (variables: V) => R }; // AS-IS
type TypedDocumentNode<R, V> = { __apiType?(variables: V): R }; // TO-BE

type AnimalQueryResult = Record<
  string,
  { name: string; id: string; age: number; [key: string]: any }
>;
type AnimalQueryVariable = Record<string, any>;

function queryAnimal<
  DN extends TypedDocumentNode<R, V>,
  R extends AnimalQueryResult,
  V extends AnimalQueryVariable
>(query: DN, variable: VariablesOf<DN>): ResultOf<DN> {
  return "" as any;
}

const dogDocumentNode = "" as TypedDocumentNode<
  { dogQuery: { name: string; id: string; age: number } },
  { id: string }
>;
const dog = queryAnimal(dogDocumentNode, { id: "5172" });

const catDocumentNode = "" as TypedDocumentNode<
  { catQuery: { name: string; id: string } },
  { id: string }
>;
const cat = queryAnimal(catDocumentNode, { id: "5713" });
```

# References
[TypeScript FAQ: Why are function parameters bivariant?](https://github.com/Microsoft/TypeScript/wiki/FAQ#why-are-function-parameters-bivariant)
[Typescript Repo: Strict function types #18654](https://github.com/microsoft/TypeScript/pull/18654)